### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build and Publish Docker Image to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: whitesands13/whitesands
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -69,7 +69,7 @@ SUBSYSTEM_DEF(server_maint)
 				continue
 
 		if (!(!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
-			winset(C, null, "command=.update_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")
+			winset(C, null, "command=\".update_ping [world.time+world.tick_lag*TICK_USAGE_REAL/100]\"") // SinguloStation edit - Fix ping display
 
 		if (MC_TICK_CHECK) //one day, when ss13 has 1000 people per server, you guys are gonna be glad I added this tick check
 			return

--- a/code/modules/client/verbs/ping.dm
+++ b/code/modules/client/verbs/ping.dm
@@ -19,4 +19,4 @@
 /client/verb/ping()
 	set name = "Ping"
 	set category = "OOC"
-	winset(src, null, "command=.display_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")
+	winset(src, null, "command=\".display_ping [world.time+world.tick_lag*TICK_USAGE_REAL/100]\"") // SinguloStation edit - Fix ping display

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -49,13 +49,6 @@
 
 		-->
 		<div class="commit sansserif">
-
-			<h2 class="date">07 August 2021</h2>
-			<h3 class="author">Urumasi updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">Cryogenic storage now applies stasis to stop your metabolism.</li>
-				<li class="tweak">You no longer snore while in deep cryogenic sleep.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -70,22 +70,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">increases the RCL's capacity to 900</li>
 			</ul>
-
-			<h2 class="date">29 June 2021</h2>
-			<h3 class="author">KubeRoot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Turbines no longer produce ridiculous power and throw tons of runtimes when the intake is a wall</li>
-				<li class="rscadd">Conveyor switches can be toggled between two-way and one-way with a screwdriver when in item form</li>
-				<li class="rscadd">Conveyor switches remember their one-way state when turned into item form</li>
-				<li class="rscadd">You can now use the Activate Held Object and Drop Object hotkeys (default Z and Q, respectively) to activate arm-implanted tools and put objects away. You must have the hand free before you can activate it this way.</li>
-				<li class="balance">Arm implant tools are no longer no-drop, and instead simply snap back if they get dropped. Don't sweat it, if you slip just press Z again.</li>
-			</ul>
-			<h3 class="author">Urumasi updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">You can now carefully walk over piles of items to avoid tripping over them.</li>
-				<li class="bugfix">We have recalibrated recyclers to stop them from eating your hardsuit helmet lights.</li>
-				<li class="bugfix">Nanotrasen apologizes for the shipment of defective deepcore pinpointers and sent a new one on the house.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -56,14 +56,6 @@
 				<li class="tweak">Cryogenic storage now applies stasis to stop your metabolism.</li>
 				<li class="tweak">You no longer snore while in deep cryogenic sleep.</li>
 			</ul>
-
-			<h2 class="date">09 July 2021</h2>
-			<h3 class="author">KubeRoot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">map export now works and can be used to save an area of the map</li>
-				<li class="rscadd">Transit tube dispenser stations are now buildable via RPD</li>
-				<li class="bugfix">Transit tube dispenser station sprite errors have been fixed. The sprites themselves have not been changed, but the names and orientation has been corrected.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -64,12 +64,6 @@
 				<li class="rscadd">Transit tube dispenser stations are now buildable via RPD</li>
 				<li class="bugfix">Transit tube dispenser station sprite errors have been fixed. The sprites themselves have not been changed, but the names and orientation has been corrected.</li>
 			</ul>
-
-			<h2 class="date">01 July 2021</h2>
-			<h3 class="author">MaltVinegar updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">increases the RCL's capacity to 900</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -98,12 +98,6 @@
 			<ul class="changes bgimages16">
 				<li class="rscadd">All constructors have a universal right-click "Toggle ore silo" verb, notably the plumbing and light constructors</li>
 			</ul>
-
-			<h2 class="date">23 June 2021</h2>
-			<h3 class="author">KubeRoot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Shuttle mass calculation</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -86,12 +86,6 @@
 				<li class="bugfix">We have recalibrated recyclers to stop them from eating your hardsuit helmet lights.</li>
 				<li class="bugfix">Nanotrasen apologizes for the shipment of defective deepcore pinpointers and sent a new one on the house.</li>
 			</ul>
-
-			<h2 class="date">28 June 2021</h2>
-			<h3 class="author">KubeRoot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Gentle slime crossbreeds can be made with pink extracts. They can be used to emulate luminescent activations of extracts.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -92,12 +92,6 @@
 			<ul class="changes bgimages16">
 				<li class="rscadd">Gentle slime crossbreeds can be made with pink extracts. They can be used to emulate luminescent activations of extracts.</li>
 			</ul>
-
-			<h2 class="date">24 June 2021</h2>
-			<h3 class="author">KubeRoot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">All constructors have a universal right-click "Toggle ore silo" verb, notably the plumbing and light constructors</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -110,12 +110,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">radial menus now ignore the anchor's current alpha, color and transform.</li>
 			</ul>
-
-			<h2 class="date">21 June 2021</h2>
-			<h3 class="author">Urumasi updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Ore vein pinpointers now correctly only show ores that are on your z-level.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -104,12 +104,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">Shuttle mass calculation</li>
 			</ul>
-
-			<h2 class="date">22 June 2021</h2>
-			<h3 class="author">KubeRoot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">radial menus now ignore the anchor's current alpha, color and transform.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelogs/AutoChangeLog-pr-33.yml
+++ b/html/changelogs/AutoChangeLog-pr-33.yml
@@ -1,0 +1,4 @@
+author: Urumasi
+delete-after: true
+changes:
+  - bugfix: Fixes ping becoming useless after really long round durations


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore